### PR TITLE
Change tag to playframework

### DIFF
--- a/activator.properties
+++ b/activator.properties
@@ -1,4 +1,4 @@
 name=scaldi-play-example
 title=Scaldi Play Example
 description=Scaldi is lightweight Scala dependency injection library. In this project you will find an example of Play 2 application that uses Scaldi for dependency injection.
-tags=scaldi,play,scala,dependency-injection,basics
+tags=scaldi,playframework,scala,dependency-injection,basics


### PR DESCRIPTION
We want to use the Activator tag `playframework` for all Play related projects.
